### PR TITLE
Fix usage of latest version of aws-encryption-sdk, explicitly use 1.4.1

### DIFF
--- a/environment-setup.sh
+++ b/environment-setup.sh
@@ -2,7 +2,7 @@
 
 T=$(date)
 
-PACKAGE_NAMES="aws-encryption-sdk pathlib flask pyopenssl requests"
+PACKAGE_NAMES="aws-encryption-sdk==1.4.1 pathlib flask pyopenssl requests"
 if [ -z ${TEST_ENVIRONMENT+x} ] || [ "${TEST_ENVIRONMENT}" != "1" ]; then
     PACKAGE_NAMES="${PACKAGE_NAMES} ikp3db"
 fi

--- a/usecase-1/environment-setup.sh
+++ b/usecase-1/environment-setup.sh
@@ -2,7 +2,7 @@
 
 T=$(date)
 
-PACKAGE_NAMES="boto3 aws-encryption-sdk pathlib flask pyopenssl requests"
+PACKAGE_NAMES="boto3 aws-encryption-sdk==1.4.1 pathlib flask pyopenssl requests"
 if [ -z ${TEST_ENVIRONMENT+x} ] || [ "${TEST_ENVIRONMENT}" != "1" ]; then
     PACKAGE_NAMES="${PACKAGE_NAMES} ikp3db"
 fi
@@ -12,13 +12,13 @@ echo $T > setup.log
 
 PIPOK=0
 echo "upgrading pip (sudo)" >> setup.log
-OUT=$(sudo /usr/bin/pip-3.6 install --upgrade pip 2>&1) # FIX!
+OUT=$(sudo python -m pip install --upgrade pip 2>&1) # FIX!
 if [ "$?" == "0" ]; then
     PIPOK=1
 else
     echo $OUT >> setup.log
     echo "upgrading pip (user)" >> setup.log
-    OUT=$(pip-3.6 install ---upgrade pip 2>&1)
+    OUT=$(python -m pip install ---upgrade pip 2>&1)
     if [ "$?" == "0" ]; then
         PIPOK=1
     else
@@ -28,7 +28,7 @@ fi
 
 if [ "$PIPOK" == "1" ]; then
     echo "calling pip install" >> setup.log
-    OUT=$(python36 -m pip install --user ${PACKAGE_NAMES})
+    OUT=$(python -m pip install --user ${PACKAGE_NAMES})
     if [ "$?" == "0" ]; then
         echo "SUCCESS: installed python dependencies ${PACKAGE_NAMES}" > ok
         cat ok

--- a/usecase-2/environment-setup.sh
+++ b/usecase-2/environment-setup.sh
@@ -2,7 +2,7 @@
 
 T=$(date)
 
-PACKAGE_NAMES="boto3 aws-encryption-sdk pathlib flask pyopenssl requests"
+PACKAGE_NAMES="boto3 aws-encryption-sdk==1.4.1 pathlib flask pyopenssl requests"
 if [ -z ${TEST_ENVIRONMENT+x} ] || [ "${TEST_ENVIRONMENT}" != "1" ]; then
     PACKAGE_NAMES="${PACKAGE_NAMES} ikp3db"
 fi
@@ -12,13 +12,13 @@ echo $T > setup.log
 
 PIPOK=0
 echo "upgrading pip (sudo)" >> setup.log
-OUT=$(sudo /usr/bin/pip-3.6 install --upgrade pip 2>&1) # FIX!
+OUT=$(sudo python -m pip install --upgrade pip 2>&1) # FIX!
 if [ "$?" == "0" ]; then
     PIPOK=1
 else
     echo $OUT >> setup.log
     echo "upgrading pip (user)" >> setup.log
-    OUT=$(pip-3.6 install ---upgrade pip 2>&1)
+    OUT=$(python -m pip install ---upgrade pip 2>&1)
     if [ "$?" == "0" ]; then
         PIPOK=1
     else
@@ -28,7 +28,7 @@ fi
 
 if [ "$PIPOK" == "1" ]; then
     echo "calling pip install" >> setup.log
-    OUT=$(python36 -m pip install --user ${PACKAGE_NAMES})
+    OUT=$(python -m pip install --user ${PACKAGE_NAMES})
     if [ "$?" == "0" ]; then
         echo "SUCCESS: installed python dependencies ${PACKAGE_NAMES}" > ok
         cat ok

--- a/usecase-3/environment-setup.sh
+++ b/usecase-3/environment-setup.sh
@@ -2,7 +2,7 @@
 
 T=$(date)
 
-PACKAGE_NAMES="boto3 aws-encryption-sdk pathlib flask pyopenssl requests"
+PACKAGE_NAMES="boto3 aws-encryption-sdk==1.4.1 pathlib flask pyopenssl requests"
 if [ -z ${TEST_ENVIRONMENT+x} ] || [ "${TEST_ENVIRONMENT}" != "1" ]; then
     PACKAGE_NAMES="${PACKAGE_NAMES} ikp3db"
 fi
@@ -12,13 +12,13 @@ echo $T > setup.log
 
 PIPOK=0
 echo "upgrading pip (sudo)" >> setup.log
-OUT=$(sudo /usr/bin/pip-3.6 install --upgrade pip 2>&1) # FIX!
+OUT=$(sudo python -m pip install --upgrade pip 2>&1) # FIX!
 if [ "$?" == "0" ]; then
     PIPOK=1
 else
     echo $OUT >> setup.log
     echo "upgrading pip (user)" >> setup.log
-    OUT=$(pip-3.6 install ---upgrade pip 2>&1)
+    OUT=$(python -m pip install ---upgrade pip 2>&1)
     if [ "$?" == "0" ]; then
         PIPOK=1
     else
@@ -28,7 +28,7 @@ fi
 
 if [ "$PIPOK" == "1" ]; then
     echo "calling pip install" >> setup.log
-    OUT=$(python36 -m pip install --user ${PACKAGE_NAMES})
+    OUT=$(python -m pip install --user ${PACKAGE_NAMES})
     if [ "$?" == "0" ]; then
         echo "SUCCESS: installed python dependencies ${PACKAGE_NAMES}" > ok
         cat ok

--- a/usecase-4/environment-setup.sh
+++ b/usecase-4/environment-setup.sh
@@ -2,7 +2,7 @@
 
 T=$(date)
 
-PACKAGE_NAMES="boto3 aws-encryption-sdk pathlib flask pyopenssl requests"
+PACKAGE_NAMES="boto3 aws-encryption-sdk==1.4.1 pathlib flask pyopenssl requests"
 if [ -z ${TEST_ENVIRONMENT+x} ] || [ "${TEST_ENVIRONMENT}" != "1" ]; then
     PACKAGE_NAMES="${PACKAGE_NAMES} ikp3db"
 fi
@@ -12,13 +12,13 @@ echo $T > setup.log
 
 PIPOK=0
 echo "upgrading pip (sudo)" >> setup.log
-OUT=$(sudo /usr/bin/pip-3.6 install --upgrade pip 2>&1) # FIX!
+OUT=$(sudo python -m pip install --upgrade pip 2>&1) # FIX!
 if [ "$?" == "0" ]; then
     PIPOK=1
 else
     echo $OUT >> setup.log
     echo "upgrading pip (user)" >> setup.log
-    OUT=$(pip-3.6 install ---upgrade pip 2>&1)
+    OUT=$(python -m pip install ---upgrade pip 2>&1)
     if [ "$?" == "0" ]; then
         PIPOK=1
     else
@@ -28,7 +28,7 @@ fi
 
 if [ "$PIPOK" == "1" ]; then
     echo "calling pip install" >> setup.log
-    OUT=$(python36 -m pip install --user ${PACKAGE_NAMES})
+    OUT=$(python -m pip install --user ${PACKAGE_NAMES})
     if [ "$?" == "0" ]; then
         echo "SUCCESS: installed python dependencies ${PACKAGE_NAMES}" > ok
         cat ok

--- a/usecase-5/environment-setup.sh
+++ b/usecase-5/environment-setup.sh
@@ -2,7 +2,7 @@
 
 T=$(date)
 
-PACKAGE_NAMES="boto3 aws-encryption-sdk pathlib flask pyopenssl requests"
+PACKAGE_NAMES="boto3 aws-encryption-sdk==1.4.1 pathlib flask pyopenssl requests"
 if [ -z ${TEST_ENVIRONMENT+x} ] || [ "${TEST_ENVIRONMENT}" != "1" ]; then
     PACKAGE_NAMES="${PACKAGE_NAMES} ikp3db"
 fi
@@ -12,13 +12,13 @@ echo $T > setup.log
 
 PIPOK=0
 echo "upgrading pip (sudo)" >> setup.log
-OUT=$(sudo /usr/bin/pip-3.6 install --upgrade pip 2>&1) # FIX!
+OUT=$(sudo python -m pip install --upgrade pip 2>&1) # FIX!
 if [ "$?" == "0" ]; then
     PIPOK=1
 else
     echo $OUT >> setup.log
     echo "upgrading pip (user)" >> setup.log
-    OUT=$(pip-3.6 install ---upgrade pip 2>&1)
+    OUT=$(python -m pip install ---upgrade pip 2>&1)
     if [ "$?" == "0" ]; then
         PIPOK=1
     else
@@ -28,7 +28,7 @@ fi
 
 if [ "$PIPOK" == "1" ]; then
     echo "calling pip install" >> setup.log
-    OUT=$(python36 -m pip install --user ${PACKAGE_NAMES})
+    OUT=$(python -m pip install --user ${PACKAGE_NAMES})
     if [ "$?" == "0" ]; then
         echo "SUCCESS: installed python dependencies ${PACKAGE_NAMES}" > ok
         cat ok

--- a/usecase-6/environment-setup.sh
+++ b/usecase-6/environment-setup.sh
@@ -2,7 +2,7 @@
 
 T=$(date)
 
-PACKAGE_NAMES="boto3 aws-encryption-sdk pathlib flask pyopenssl requests"
+PACKAGE_NAMES="boto3 aws-encryption-sdk==1.4.1 pathlib flask pyopenssl requests"
 if [ -z ${TEST_ENVIRONMENT+x} ] || [ "${TEST_ENVIRONMENT}" != "1" ]; then
     PACKAGE_NAMES="${PACKAGE_NAMES} ikp3db"
 fi
@@ -12,13 +12,13 @@ echo $T > setup.log
 
 PIPOK=0
 echo "upgrading pip (sudo)" >> setup.log
-OUT=$(sudo /usr/bin/pip-3.6 install --upgrade pip 2>&1) # FIX!
+OUT=$(sudo python -m pip install --upgrade pip 2>&1) # FIX!
 if [ "$?" == "0" ]; then
     PIPOK=1
 else
     echo $OUT >> setup.log
     echo "upgrading pip (user)" >> setup.log
-    OUT=$(pip-3.6 install ---upgrade pip 2>&1)
+    OUT=$(python -m pip install ---upgrade pip 2>&1)
     if [ "$?" == "0" ]; then
         PIPOK=1
     else
@@ -28,7 +28,7 @@ fi
 
 if [ "$PIPOK" == "1" ]; then
     echo "calling pip install" >> setup.log
-    OUT=$(python36 -m pip install --user ${PACKAGE_NAMES})
+    OUT=$(python -m pip install --user ${PACKAGE_NAMES})
     if [ "$?" == "0" ]; then
         echo "SUCCESS: installed python dependencies ${PACKAGE_NAMES}" > ok
         cat ok

--- a/usecase-7/environment-setup.sh
+++ b/usecase-7/environment-setup.sh
@@ -2,7 +2,7 @@
 
 T=$(date)
 
-PACKAGE_NAMES="boto3 aws-encryption-sdk pathlib flask pyopenssl requests"
+PACKAGE_NAMES="boto3 aws-encryption-sdk==1.4.1 pathlib flask pyopenssl requests"
 if [ -z ${TEST_ENVIRONMENT+x} ] || [ "${TEST_ENVIRONMENT}" != "1" ]; then
     PACKAGE_NAMES="${PACKAGE_NAMES} ikp3db"
 fi
@@ -12,13 +12,13 @@ echo $T > setup.log
 
 PIPOK=0
 echo "upgrading pip (sudo)" >> setup.log
-OUT=$(sudo /usr/bin/pip-3.6 install --upgrade pip 2>&1) # FIX!
+OUT=$(sudo python -m pip install --upgrade pip 2>&1) # FIX!
 if [ "$?" == "0" ]; then
     PIPOK=1
 else
     echo $OUT >> setup.log
     echo "upgrading pip (user)" >> setup.log
-    OUT=$(pip-3.6 install ---upgrade pip 2>&1)
+    OUT=$(python -m pip install ---upgrade pip 2>&1)
     if [ "$?" == "0" ]; then
         PIPOK=1
     else
@@ -28,7 +28,7 @@ fi
 
 if [ "$PIPOK" == "1" ]; then
     echo "calling pip install" >> setup.log
-    OUT=$(python36 -m pip install --user ${PACKAGE_NAMES})
+    OUT=$(python -m pip -m pip install --user ${PACKAGE_NAMES})
     if [ "$?" == "0" ]; then
         echo "SUCCESS: installed python dependencies ${PACKAGE_NAMES}" > ok
         cat ok

--- a/usecase-8/environment-setup.sh
+++ b/usecase-8/environment-setup.sh
@@ -2,7 +2,7 @@
 
 T=$(date)
 
-PACKAGE_NAMES="boto3 aws-encryption-sdk pathlib flask pyopenssl requests"
+PACKAGE_NAMES="boto3 aws-encryption-sdk==1.4.1 pathlib flask pyopenssl requests"
 if [ -z ${TEST_ENVIRONMENT+x} ] || [ "${TEST_ENVIRONMENT}" != "1" ]; then
     PACKAGE_NAMES="${PACKAGE_NAMES} ikp3db"
 fi
@@ -12,13 +12,13 @@ echo $T > setup.log
 
 PIPOK=0
 echo "upgrading pip (sudo)" >> setup.log
-OUT=$(sudo /usr/bin/pip-3.6 install --upgrade pip 2>&1) # FIX!
+OUT=$(sudo python -m pip install --upgrade pip 2>&1) # FIX!
 if [ "$?" == "0" ]; then
     PIPOK=1
 else
     echo $OUT >> setup.log
     echo "upgrading pip (user)" >> setup.log
-    OUT=$(pip-3.6 install ---upgrade pip 2>&1)
+    OUT=$(python -m pip install ---upgrade pip 2>&1)
     if [ "$?" == "0" ]; then
         PIPOK=1
     else
@@ -28,7 +28,7 @@ fi
 
 if [ "$PIPOK" == "1" ]; then
     echo "calling pip install" >> setup.log
-    OUT=$(python36 -m pip install --user ${PACKAGE_NAMES})
+    OUT=$(python -m pip install --user ${PACKAGE_NAMES})
     if [ "$?" == "0" ]; then
         echo "SUCCESS: installed python dependencies ${PACKAGE_NAMES}" > ok
         cat ok


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the latest releases, KMSMasterKeyProvider, encrypt, decrypt, and stream methods in the aws_encryption_sdk module are deprecated (https://github.com/aws/aws-encryption-sdk-python/releases/tag/v1.7.0). This breaks all examples of this workshop.

This pull requests fixes that compatibility while all examples are rewritten, making this workshop usable again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
