### PR TITLE
Add IGW attachment dependency for ALB creation

### DIFF
--- a/usecase-9/cf-templates/template-app-dev.yaml
+++ b/usecase-9/cf-templates/template-app-dev.yaml
@@ -296,6 +296,8 @@ Resources:
       
    # Creating a ALB in CF - Target group and listener will be createdin Boto      
    ApplicationLoadBalancer:
+      DependsOn:
+        - GatewayAttachment
       Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
       Properties:
          Scheme: internet-facing


### PR DESCRIPTION
Solves possible race condition where ALB creation fails during deploy because IGW hasn't been attached yet.

*Issue #, if available:*

*Description of changes:*
added 'Depends on' param to line 299

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
